### PR TITLE
Implement print buildin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Tree-walking visitor. `Interpreter.run()` takes an `AstNode` (typically `Program
 **Return**: implemented by throwing a `Return` error caught in `visitFunctionCall`.
 
 ### Test structure
-Unit tests are colocated with source files (`*.test.ts`). `src/Interpreter/examples/` holds integration tests for complex multi-statement programs (e.g., fibonacci).
+Unit tests are colocated with source files (`*.test.ts`). `src/examples/` holds integration tests for complex multi-statement programs (e.g., fibonacci).
 
 ## Development Lifecycle
 
@@ -85,7 +85,7 @@ For each affected layer, write tests first, then implement. Work in this order:
 
 **Interpreter** (if new runtime behavior is needed)
 1. Add unit tests colocated with the implementation (e.g., `Interpreter.test.ts` or `objects/LuckyFoo.test.ts`)
-2. Add integration tests in `src/Interpreter/examples/` for complex multi-statement scenarios
+2. Add integration tests in `src/examples/` for complex multi-statement scenarios
 3. Implement in `src/Interpreter/`
 4. Run `yarn test -- --testPathPattern=Interpreter`
 

--- a/openspec/changes/archive/2026-05-05-add-print-builtin/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-05-add-print-builtin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/archive/2026-05-05-add-print-builtin/design.md
+++ b/openspec/changes/archive/2026-05-05-add-print-builtin/design.md
@@ -1,0 +1,65 @@
+## Context
+
+The interpreter currently recognises only one callable type: `LuckyFunction`. `visitFunctionCall` hard-checks `instanceof LuckyFunction` and throws for anything else. There is no mechanism for native (JS-backed) functions, and no protocol for converting a `LuckyObject` to a printable string.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a `print(x)` built-in with arity 1
+- Establish an extensible pattern for future built-ins (zero changes to interpreter dispatch when adding a new one)
+- Enforce a `display(): string` contract on all runtime value types at compile time
+
+**Non-Goals:**
+- Variadic `print` (deferred until strings are added and multi-arg printing is useful)
+- Protecting built-ins from being overwritten by user code (TODO — current `set()` semantics allow it; acceptable for now)
+- A `local` / `global` keyword to control scoping of built-in redefinition
+
+## Decisions
+
+### 1. `LuckyBuiltin` wraps a plain JS closure — no shared abstract base with `LuckyFunction`
+
+`LuckyBuiltin` holds a `(args: LuckyObject[]) => LuckyObject` closure. It has a fixed `arity: number` field. Execution is self-contained: no interpreter reference needed.
+
+`LuckyFunction` execution stays in `visitFunctionCall` because it needs `interpreter.visit()` to walk its AST. Forcing a common `call(args, interpreter)` interface would introduce a circular import (`LuckyFunction → Interpreter → LuckyFunction`) and pollute builtins with an interpreter argument they never use.
+
+**Alternative considered:** A `LuckyCallable` abstract base with `call(args, interpreter)`. Rejected because: circular dependency risk, and builtins genuinely don't need the interpreter — the distinction is real, not incidental.
+
+### 2. `builtins.ts` registry as the single extension point
+
+All built-ins are defined in `src/Interpreter/builtins.ts` as a `Record<string, LuckyBuiltin>`. Adding a new built-in is one entry in this file — `Interpreter.ts`, `LuckyBuiltin`, and the dispatch logic are untouched.
+
+### 3. `visitFunctionCall` gets an early-return branch for `LuckyBuiltin`
+
+```
+lookup(name)
+  → instanceof LuckyBuiltin  → validate arity, evaluate args, call → return
+  → instanceof LuckyFunction → existing logic
+  → else                     → RuntimeError "'name' is not callable"
+```
+
+Existing `LuckyFunction` path is unchanged.
+
+### 4. `display(): string` is abstract on `LuckyObject`
+
+TypeScript enforces implementation on every subclass. Display values:
+
+| Type | `display()` |
+|---|---|
+| `LuckyNumber` | `String(this.value)` |
+| `LuckyBoolean` | `"true"` / `"false"` |
+| `LuckyNothing` | `"nothing"` |
+| `LuckyString` | the raw string value (no quotes) |
+| `LuckyFunction` | `"<function name>"` or `"<function>"` for anonymous |
+| `LuckyBuiltin` | `"<builtin name>"` |
+
+### 5. Built-ins are seeded via `setLocal` in the `Interpreter` constructor
+
+Root scope is the `private scope = new SymbolTable()` field. The constructor iterates `BUILTINS` and calls `this.scope.setLocal(name, builtin)`. User code can overwrite them via the normal `set()` walk-up semantics.
+
+## Risks / Trade-offs
+
+- **Built-ins are globally mutable** — `print = myFn` anywhere in user code replaces the built-in in the root scope. Acceptable for now; mitigate later with a read-only scope layer or `setLocal`-only assignment for the root scope. TODO left in code.
+
+## Open Questions
+
+_(none — all decisions made during explore session)_

--- a/openspec/changes/archive/2026-05-05-add-print-builtin/proposal.md
+++ b/openspec/changes/archive/2026-05-05-add-print-builtin/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Lucky Script has no way to produce output. Without `print`, programs can only be observed by reading the return value of the last expression — unusable in the REPL and impossible to test multi-statement programs interactively. Adding `print` unblocks every subsequent feature from being testable end-to-end.
+
+## What Changes
+
+- Introduce a `print` built-in function (arity 1) that writes its argument's string representation to stdout and returns `nothing`
+- Add a `display(): string` abstract method to `LuckyObject`, implemented by every runtime value type
+- Introduce a `LuckyBuiltin` class to represent native (JS-backed) functions
+- Introduce a `builtins.ts` registry as the single place to add future built-ins
+- Seed built-ins into the root scope at interpreter startup
+
+## Capabilities
+
+### New Capabilities
+
+- `print-builtin`: The `print(x)` built-in function and the infrastructure supporting native functions (LuckyBuiltin class, builtins registry, display protocol)
+
+### Modified Capabilities
+
+_(none — no existing spec-level requirements change)_
+
+## Impact
+
+- `src/Interpreter/objects/LuckyObject.ts` — new abstract method `display()`
+- `src/Interpreter/objects/` — all existing subclasses gain `display()` implementation
+- `src/Interpreter/objects/LuckyBuiltin.ts` — new file
+- `src/Interpreter/builtins.ts` — new file (registry)
+- `src/Interpreter/Interpreter.ts` — constructor seeds built-ins; `visitFunctionCall` gains a `LuckyBuiltin` early-return branch
+- No parser or lexer changes required
+- No breaking changes to existing programs

--- a/openspec/changes/archive/2026-05-05-add-print-builtin/specs/print-builtin/spec.md
+++ b/openspec/changes/archive/2026-05-05-add-print-builtin/specs/print-builtin/spec.md
@@ -72,7 +72,7 @@ Every concrete `LuckyObject` subtype SHALL implement `display(): string` returni
 - **THEN** it returns `"<function>"`
 
 ### Requirement: helloWorld integration test demonstrates print with a user-defined function
-A `src/Interpreter/examples/helloWorld.test.ts` file SHALL exist demonstrating `print` used inside a named function. The function `sayHello` SHALL accept a `name` argument and call `print` with the greeting `"Hello, " + name + "!"`.
+A `src/examples/helloWorld.test.ts` file SHALL exist demonstrating `print` used inside a named function. The function `sayHello` SHALL accept a `name` argument and call `print` with the greeting `"Hello, " + name + "!"`.
 
 #### Scenario: sayHello prints the expected greeting
 - **WHEN** the program defines `sayHello(name)` and calls `sayHello("World")`

--- a/openspec/changes/archive/2026-05-05-add-print-builtin/specs/print-builtin/spec.md
+++ b/openspec/changes/archive/2026-05-05-add-print-builtin/specs/print-builtin/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: print built-in is available without declaration
+The interpreter SHALL pre-populate the root scope with a `print` identifier bound to a native callable before executing any user code.
+
+#### Scenario: print is callable without prior declaration
+- **WHEN** user code calls `print(42)` with no prior definition of `print`
+- **THEN** the call succeeds and does not throw a NameError
+
+### Requirement: print writes its argument's display representation to stdout
+`print(x)` SHALL call `console.log` with the `display()` string of its single argument and return `nothing`.
+
+#### Scenario: print a number
+- **WHEN** `print(42)` is evaluated
+- **THEN** `"42"` is written to stdout and the expression evaluates to `nothing`
+
+#### Scenario: print a boolean true
+- **WHEN** `print(true)` is evaluated
+- **THEN** `"true"` is written to stdout
+
+#### Scenario: print a boolean false
+- **WHEN** `print(false)` is evaluated
+- **THEN** `"false"` is written to stdout
+
+#### Scenario: print nothing
+- **WHEN** `print(nothing)` is evaluated
+- **THEN** `"nothing"` is written to stdout
+
+#### Scenario: print a string
+- **WHEN** `print("hello")` is evaluated
+- **THEN** `"hello"` is written to stdout (no surrounding quotes)
+
+### Requirement: print accepts exactly one argument
+`print` SHALL have arity 1. Calling it with any other number of arguments SHALL throw a RuntimeError.
+
+#### Scenario: zero arguments
+- **WHEN** `print()` is evaluated
+- **THEN** a RuntimeError is thrown indicating wrong number of arguments
+
+#### Scenario: two arguments
+- **WHEN** `print(1, 2)` is evaluated
+- **THEN** a RuntimeError is thrown indicating wrong number of arguments
+
+### Requirement: print can be overwritten by user code
+Because `print` lives in the root scope and assignment uses the standard walk-up semantics, user code SHALL be able to replace `print` with any value.
+
+#### Scenario: overwrite print at top level
+- **WHEN** user assigns `print = myFn` at the top level and then calls `print(1)`
+- **THEN** `myFn` is called instead of the native built-in
+
+### Requirement: all LuckyObject subtypes implement display
+Every concrete `LuckyObject` subtype SHALL implement `display(): string` returning a human-readable representation.
+
+#### Scenario: LuckyNumber display
+- **WHEN** `display()` is called on `LuckyNumber(3.14)`
+- **THEN** it returns `"3.14"`
+
+#### Scenario: LuckyBoolean display
+- **WHEN** `display()` is called on `LuckyBoolean.True`
+- **THEN** it returns `"true"`
+
+#### Scenario: LuckyNothing display
+- **WHEN** `display()` is called on `LuckyNothing.Instance`
+- **THEN** it returns `"nothing"`
+
+#### Scenario: LuckyFunction display with name
+- **WHEN** `display()` is called on a named `LuckyFunction` with name `"foo"`
+- **THEN** it returns `"<function foo>"`
+
+#### Scenario: LuckyFunction display anonymous
+- **WHEN** `display()` is called on an anonymous `LuckyFunction` (name is undefined)
+- **THEN** it returns `"<function>"`
+
+### Requirement: helloWorld integration test demonstrates print with a user-defined function
+A `src/Interpreter/examples/helloWorld.test.ts` file SHALL exist demonstrating `print` used inside a named function. The function `sayHello` SHALL accept a `name` argument and call `print` with the greeting `"Hello, " + name + "!"`.
+
+#### Scenario: sayHello prints the expected greeting
+- **WHEN** the program defines `sayHello(name)` and calls `sayHello("World")`
+- **THEN** `"Hello, World!"` is written to stdout

--- a/openspec/changes/archive/2026-05-05-add-print-builtin/tasks.md
+++ b/openspec/changes/archive/2026-05-05-add-print-builtin/tasks.md
@@ -1,0 +1,39 @@
+## 1. display() protocol on LuckyObject
+
+- [x] 1.1 Add `abstract display(): string` to `LuckyObject`
+- [x] 1.2 Implement `display()` on `LuckyNumber` — returns `String(this.value)`
+- [x] 1.3 Implement `display()` on `LuckyBoolean` — returns `"true"` or `"false"`
+- [x] 1.4 Implement `display()` on `LuckyNothing` — returns `"nothing"`
+- [x] 1.5 Implement `display()` on `LuckyString` — returns the raw string value
+- [x] 1.6 Implement `display()` on `LuckyFunction` — returns `"<function name>"` or `"<function>"` for anonymous
+- [x] 1.7 Run `yarn typecheck` — confirm no subclass is missing `display()`
+
+## 2. LuckyBuiltin class
+
+- [x] 2.1 Create `src/Interpreter/objects/LuckyBuiltin.ts` — class with `name: string`, `arity: number`, private `fn: (args: LuckyObject[]) => LuckyObject`, `call(args)` method, `display()` returning `"<builtin name>"`, and `toBoolean()` returning `LuckyBoolean.True`
+- [x] 2.2 Export `LuckyBuiltin` from `src/Interpreter/objects/index.ts`
+- [x] 2.3 Write unit tests for `LuckyBuiltin` — verify `call()` invokes the native fn and `display()` returns the expected string
+
+## 3. Builtins registry
+
+- [x] 3.1 Create `src/Interpreter/builtins.ts` — export `BUILTINS: Record<string, LuckyBuiltin>` with a `print` entry: arity 1, calls `console.log(args[0].display())`, returns `LuckyNothing.Instance`
+
+## 4. Interpreter wiring
+
+- [x] 4.1 In `Interpreter` constructor, iterate `BUILTINS` and call `this.scope.setLocal(name, builtin)` for each entry
+- [x] 4.2 In `visitFunctionCall`, add an early-return branch: if `obj instanceof LuckyBuiltin`, validate arity, evaluate args, call `obj.call(evaluatedArgs)`, and return the result
+- [x] 4.3 Add a TODO comment near the root-scope seeding noting that builtins can currently be overwritten by user code
+
+## 5. Tests
+
+- [x] 5.1 Add unit tests for `display()` on each type (number, boolean, nothing, function named, function anonymous)
+- [x] 5.2 Add integration test: `print(42)` writes `"42"` to stdout and returns `nothing`
+- [x] 5.3 Add integration test: `print(true)`, `print(false)`, `print(nothing)` each write the correct string
+- [x] 5.4 Add integration test: calling `print()` with zero args throws RuntimeError
+- [x] 5.5 Add integration test: calling `print(1, 2)` throws RuntimeError
+- [x] 5.6 Add integration test: overwriting `print` and calling the replacement
+- [x] 5.7 Create `src/Interpreter/examples/helloWorld.test.ts` — define `sayHello(name)` that calls `print("Hello, " + name + "!")`, assert stdout receives `"Hello, World!"`
+
+## 6. Quality check
+
+- [x] 6.1 Run `yarn lint && yarn test` — all passing

--- a/openspec/changes/archive/2026-05-05-add-print-builtin/tasks.md
+++ b/openspec/changes/archive/2026-05-05-add-print-builtin/tasks.md
@@ -32,7 +32,7 @@
 - [x] 5.4 Add integration test: calling `print()` with zero args throws RuntimeError
 - [x] 5.5 Add integration test: calling `print(1, 2)` throws RuntimeError
 - [x] 5.6 Add integration test: overwriting `print` and calling the replacement
-- [x] 5.7 Create `src/Interpreter/examples/helloWorld.test.ts` — define `sayHello(name)` that calls `print("Hello, " + name + "!")`, assert stdout receives `"Hello, World!"`
+- [x] 5.7 Create `src/examples/helloWorld.test.ts` — define `sayHello(name)` that calls `print("Hello, " + name + "!")`, assert stdout receives `"Hello, World!"`
 
 ## 6. Quality check
 

--- a/openspec/changes/archive/2026-05-05-add-type-builtin/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-05-add-type-builtin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/archive/2026-05-05-add-type-builtin/design.md
+++ b/openspec/changes/archive/2026-05-05-add-type-builtin/design.md
@@ -1,0 +1,18 @@
+## Context
+
+Lucky Script's interpreter represents all values as `LuckyObject` subclasses. Builtins are registered in `builtins.ts` as `LuckyBuiltin` instances with a fixed arity and a native function.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `type()` as a builtin that returns a string type name
+
+**Non-Goals:**
+- Type coercion or casting
+- Distinguishing user-defined functions from builtins (both return `"function"`)
+
+## Decisions
+
+### Decision 1: Use `instanceof` checks in the native function
+
+The native function receives a `LuckyObject[]`. We check `instanceof` in order (LuckyNumber, LuckyString, LuckyBoolean, LuckyNothing, LuckyFunction/LuckyBuiltin) and return a `LuckyString` with the type name. No changes to `LuckyObject` base class needed.

--- a/openspec/changes/archive/2026-05-05-add-type-builtin/proposal.md
+++ b/openspec/changes/archive/2026-05-05-add-type-builtin/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+Lucky Script has no way to inspect a value's type at runtime. This makes it impossible to write generic code that branches on type — a common need in dynamic languages.
+
+## What Changes
+
+- A new `type()` builtin is available in all Lucky Script programs
+- `type(value)` returns a string naming the value's type
+
+## Capabilities
+
+### New Capabilities
+- `type`: Returns the runtime type of a value as a string (`"number"`, `"string"`, `"boolean"`, `"nothing"`, `"function"`)
+
+### Modified Capabilities
+
+## Impact
+
+- `src/Interpreter/builtins.ts`: add `type` entry
+- `src/Interpreter/examples/type.test.ts`: integration tests

--- a/openspec/changes/archive/2026-05-05-add-type-builtin/proposal.md
+++ b/openspec/changes/archive/2026-05-05-add-type-builtin/proposal.md
@@ -17,4 +17,4 @@ Lucky Script has no way to inspect a value's type at runtime. This makes it impo
 ## Impact
 
 - `src/Interpreter/builtins.ts`: add `type` entry
-- `src/Interpreter/examples/type.test.ts`: integration tests
+- `src/examples/type.test.ts`: integration tests

--- a/openspec/changes/archive/2026-05-05-add-type-builtin/specs/type/spec.md
+++ b/openspec/changes/archive/2026-05-05-add-type-builtin/specs/type/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: type() returns the type name of a value
+
+The `type` builtin SHALL accept exactly one argument and return a string naming its runtime type.
+
+#### Scenario: type of a number
+
+- **WHEN** `type(42)` is evaluated
+- **THEN** the result is the string `"number"`
+
+#### Scenario: type of a string
+
+- **WHEN** `type("hello")` is evaluated
+- **THEN** the result is the string `"string"`
+
+#### Scenario: type of true
+
+- **WHEN** `type(true)` is evaluated
+- **THEN** the result is the string `"boolean"`
+
+#### Scenario: type of false
+
+- **WHEN** `type(false)` is evaluated
+- **THEN** the result is the string `"boolean"`
+
+#### Scenario: type of nothing
+
+- **WHEN** `type(nothing)` is evaluated
+- **THEN** the result is the string `"nothing"`
+
+#### Scenario: type of a user-defined function
+
+- **WHEN** a function is declared and passed to `type()`
+- **THEN** the result is the string `"function"`
+
+#### Scenario: wrong arity
+
+- **WHEN** `type()` is called with zero arguments
+- **THEN** a RuntimeError is thrown
+
+#### Scenario: wrong arity with two args
+
+- **WHEN** `type(1, 2)` is called with two arguments
+- **THEN** a RuntimeError is thrown

--- a/openspec/changes/archive/2026-05-05-add-type-builtin/tasks.md
+++ b/openspec/changes/archive/2026-05-05-add-type-builtin/tasks.md
@@ -4,7 +4,7 @@
 
 ## 2. Tests
 
-- [x] 2.1 Add integration tests in `src/Interpreter/examples/type.test.ts` covering all scenarios from the spec (number, string, boolean, nothing, function, wrong arity)
+- [x] 2.1 Add integration tests in `src/examples/type.test.ts` covering all scenarios from the spec (number, string, boolean, nothing, function, wrong arity)
 
 ## 3. Verify
 

--- a/openspec/changes/archive/2026-05-05-add-type-builtin/tasks.md
+++ b/openspec/changes/archive/2026-05-05-add-type-builtin/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+- [x] 1.1 Add `type` builtin to `src/Interpreter/builtins.ts` using `instanceof` checks to return the type name as a `LuckyString`
+
+## 2. Tests
+
+- [x] 2.1 Add integration tests in `src/Interpreter/examples/type.test.ts` covering all scenarios from the spec (number, string, boolean, nothing, function, wrong arity)
+
+## 3. Verify
+
+- [x] 3.1 Run `yarn lint && yarn test` — all checks pass

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/print-builtin/spec.md
+++ b/openspec/specs/print-builtin/spec.md
@@ -1,0 +1,77 @@
+### Requirement: print built-in is available without declaration
+The interpreter SHALL pre-populate the root scope with a `print` identifier bound to a native callable before executing any user code.
+
+#### Scenario: print is callable without prior declaration
+- **WHEN** user code calls `print(42)` with no prior definition of `print`
+- **THEN** the call succeeds and does not throw a NameError
+
+### Requirement: print writes its argument's display representation to stdout
+`print(x)` SHALL call `console.log` with the `display()` string of its single argument and return `nothing`.
+
+#### Scenario: print a number
+- **WHEN** `print(42)` is evaluated
+- **THEN** `"42"` is written to stdout and the expression evaluates to `nothing`
+
+#### Scenario: print a boolean true
+- **WHEN** `print(true)` is evaluated
+- **THEN** `"true"` is written to stdout
+
+#### Scenario: print a boolean false
+- **WHEN** `print(false)` is evaluated
+- **THEN** `"false"` is written to stdout
+
+#### Scenario: print nothing
+- **WHEN** `print(nothing)` is evaluated
+- **THEN** `"nothing"` is written to stdout
+
+#### Scenario: print a string
+- **WHEN** `print("hello")` is evaluated
+- **THEN** `"hello"` is written to stdout (no surrounding quotes)
+
+### Requirement: print accepts exactly one argument
+`print` SHALL have arity 1. Calling it with any other number of arguments SHALL throw a RuntimeError.
+
+#### Scenario: zero arguments
+- **WHEN** `print()` is evaluated
+- **THEN** a RuntimeError is thrown indicating wrong number of arguments
+
+#### Scenario: two arguments
+- **WHEN** `print(1, 2)` is evaluated
+- **THEN** a RuntimeError is thrown indicating wrong number of arguments
+
+### Requirement: print can be overwritten by user code
+Because `print` lives in the root scope and assignment uses the standard walk-up semantics, user code SHALL be able to replace `print` with any value.
+
+#### Scenario: overwrite print at top level
+- **WHEN** user assigns `print = myFn` at the top level and then calls `print(1)`
+- **THEN** `myFn` is called instead of the native built-in
+
+### Requirement: all LuckyObject subtypes implement display
+Every concrete `LuckyObject` subtype SHALL implement `display(): string` returning a human-readable representation.
+
+#### Scenario: LuckyNumber display
+- **WHEN** `display()` is called on `LuckyNumber(3.14)`
+- **THEN** it returns `"3.14"`
+
+#### Scenario: LuckyBoolean display
+- **WHEN** `display()` is called on `LuckyBoolean.True`
+- **THEN** it returns `"true"`
+
+#### Scenario: LuckyNothing display
+- **WHEN** `display()` is called on `LuckyNothing.Instance`
+- **THEN** it returns `"nothing"`
+
+#### Scenario: LuckyFunction display with name
+- **WHEN** `display()` is called on a named `LuckyFunction` with name `"foo"`
+- **THEN** it returns `"<function foo>"`
+
+#### Scenario: LuckyFunction display anonymous
+- **WHEN** `display()` is called on an anonymous `LuckyFunction` (name is undefined)
+- **THEN** it returns `"<function>"`
+
+### Requirement: helloWorld integration test demonstrates print with a user-defined function
+A `src/Interpreter/examples/helloWorld.test.ts` file SHALL exist demonstrating `print` used inside a named function. The function `sayHello` SHALL accept a `name` argument and call `print` with the greeting `"Hello, " + name + "!"`.
+
+#### Scenario: sayHello prints the expected greeting
+- **WHEN** the program defines `sayHello(name)` and calls `sayHello("World")`
+- **THEN** `"Hello, World!"` is written to stdout

--- a/openspec/specs/print-builtin/spec.md
+++ b/openspec/specs/print-builtin/spec.md
@@ -70,7 +70,7 @@ Every concrete `LuckyObject` subtype SHALL implement `display(): string` returni
 - **THEN** it returns `"<function>"`
 
 ### Requirement: helloWorld integration test demonstrates print with a user-defined function
-A `src/Interpreter/examples/helloWorld.test.ts` file SHALL exist demonstrating `print` used inside a named function. The function `sayHello` SHALL accept a `name` argument and call `print` with the greeting `"Hello, " + name + "!"`.
+A `src/examples/helloWorld.test.ts` file SHALL exist demonstrating `print` used inside a named function. The function `sayHello` SHALL accept a `name` argument and call `print` with the greeting `"Hello, " + name + "!"`.
 
 #### Scenario: sayHello prints the expected greeting
 - **WHEN** the program defines `sayHello(name)` and calls `sayHello("World")`

--- a/openspec/specs/type/spec.md
+++ b/openspec/specs/type/spec.md
@@ -1,0 +1,49 @@
+# type Specification
+
+## Purpose
+TBD - created by archiving change add-type-builtin. Update Purpose after archive.
+## Requirements
+### Requirement: type() returns the type name of a value
+
+The `type` builtin SHALL accept exactly one argument and return a string naming its runtime type.
+
+#### Scenario: type of a number
+
+- **WHEN** `type(42)` is evaluated
+- **THEN** the result is the string `"number"`
+
+#### Scenario: type of a string
+
+- **WHEN** `type("hello")` is evaluated
+- **THEN** the result is the string `"string"`
+
+#### Scenario: type of true
+
+- **WHEN** `type(true)` is evaluated
+- **THEN** the result is the string `"boolean"`
+
+#### Scenario: type of false
+
+- **WHEN** `type(false)` is evaluated
+- **THEN** the result is the string `"boolean"`
+
+#### Scenario: type of nothing
+
+- **WHEN** `type(nothing)` is evaluated
+- **THEN** the result is the string `"nothing"`
+
+#### Scenario: type of a user-defined function
+
+- **WHEN** a function is declared and passed to `type()`
+- **THEN** the result is the string `"function"`
+
+#### Scenario: wrong arity
+
+- **WHEN** `type()` is called with zero arguments
+- **THEN** a RuntimeError is thrown
+
+#### Scenario: wrong arity with two args
+
+- **WHEN** `type(1, 2)` is called with two arguments
+- **THEN** a RuntimeError is thrown
+

--- a/src/Interpreter/Interpreter.ts
+++ b/src/Interpreter/Interpreter.ts
@@ -2,6 +2,7 @@ import { Return } from "./ControlFlow";
 import { RuntimeError } from "./errors";
 import {
   LuckyBoolean,
+  LuckyBuiltin,
   LuckyFunction,
   LuckyNothing,
   LuckyNumber,
@@ -9,6 +10,7 @@ import {
   LuckyString,
 } from "./objects";
 import { SymbolTable } from "./SymbolTable";
+import { BUILTINS } from "./builtins";
 import { AstNode, BinaryOperation, Numeral, UnaryOperation } from "../Parser";
 import {
   BooleanLiteral,
@@ -27,7 +29,14 @@ export class Interpreter {
   constructor(
     public readonly node: AstNode,
     private scope = new SymbolTable(),
-  ) {}
+  ) {
+    // TODO: builtins live in root scope and can be overwritten by user code
+    // via the standard set() walk-up semantics — improve with a read-only
+    // scope layer in the future.
+    for (const [name, builtin] of Object.entries(BUILTINS)) {
+      this.scope.setLocal(name, builtin);
+    }
+  }
 
   run(): undefined | boolean | number | string {
     const luckyObject = this.visit(this.node);
@@ -141,6 +150,16 @@ export class Interpreter {
     const { name } = functionCall;
 
     const luckyFunction = this.scope.lookup(name);
+
+    if (luckyFunction instanceof LuckyBuiltin) {
+      if (luckyFunction.arity !== functionCall.args.length) {
+        throw new RuntimeError(
+          `Function ${name} takes exactly ${luckyFunction.arity} parameters`,
+        );
+      }
+      const args = functionCall.args.map((arg) => this.visit(arg));
+      return luckyFunction.call(args);
+    }
 
     if (!(luckyFunction instanceof LuckyFunction)) {
       throw new RuntimeError(`The given identifier '${name}' is not callable`);

--- a/src/Interpreter/builtins.ts
+++ b/src/Interpreter/builtins.ts
@@ -1,0 +1,27 @@
+import { LuckyBoolean } from "./objects/LuckyBoolean";
+import { LuckyBuiltin } from "./objects/LuckyBuiltin";
+import { LuckyFunction } from "./objects/LuckyFunction";
+import { LuckyNothing } from "./objects/LuckyNothing";
+import { LuckyNumber } from "./objects/LuckyNumber";
+import { LuckyObject } from "./objects";
+import { LuckyString } from "./objects/LuckyString";
+
+function typeName(arg: LuckyObject): string {
+  if (arg instanceof LuckyNumber) return "number";
+  if (arg instanceof LuckyString) return "string";
+  if (arg instanceof LuckyBoolean) return "boolean";
+  if (arg instanceof LuckyNothing) return "nothing";
+  if (arg instanceof LuckyFunction || arg instanceof LuckyBuiltin)
+    return "function";
+  return "unknown";
+}
+
+export const BUILTINS: Record<string, LuckyBuiltin> = {
+  print: new LuckyBuiltin("print", 1, ([arg]) => {
+    console.log(arg.display());
+    return LuckyNothing.Instance;
+  }),
+  type: new LuckyBuiltin("type", 1, ([arg]) => {
+    return new LuckyString(typeName(arg));
+  }),
+};

--- a/src/Interpreter/examples/helloWorld.test.ts
+++ b/src/Interpreter/examples/helloWorld.test.ts
@@ -1,0 +1,23 @@
+import { Lexer } from "../../Lexer";
+import { Parser } from "../../Parser";
+import { Interpreter } from "../Interpreter";
+
+it("sayHello prints a personalised greeting", () => {
+  const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+  const script = `
+    function sayHello(name) {
+      print("Hello, " + name + "!")
+    }
+
+    sayHello("World")
+  `;
+
+  const tokens = new Lexer(script).tokenize();
+  const ast = new Parser(tokens).parse();
+  new Interpreter(ast).run();
+
+  expect(consoleSpy).toHaveBeenCalledWith("Hello, World!");
+
+  consoleSpy.mockRestore();
+});

--- a/src/Interpreter/examples/print.test.ts
+++ b/src/Interpreter/examples/print.test.ts
@@ -1,0 +1,69 @@
+import { Lexer } from "../../Lexer";
+import { Parser } from "../../Parser";
+import { Interpreter } from "../Interpreter";
+import { RuntimeError } from "../errors";
+
+function run(script: string): undefined | boolean | number | string {
+  const tokens = new Lexer(script).tokenize();
+  const ast = new Parser(tokens).parse();
+  return new Interpreter(ast).run();
+}
+
+describe("print builtin", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("prints a number and returns nothing", () => {
+    const result = run("print(42)");
+    expect(consoleSpy).toHaveBeenCalledWith("42");
+    expect(result).toBeUndefined();
+  });
+
+  it("prints true", () => {
+    run("print(true)");
+    expect(consoleSpy).toHaveBeenCalledWith("true");
+  });
+
+  it("prints false", () => {
+    run("print(false)");
+    expect(consoleSpy).toHaveBeenCalledWith("false");
+  });
+
+  it("prints nothing", () => {
+    run("print(nothing)");
+    expect(consoleSpy).toHaveBeenCalledWith("nothing");
+  });
+
+  it("prints a string without surrounding quotes", () => {
+    run('print("hello")');
+    expect(consoleSpy).toHaveBeenCalledWith("hello");
+  });
+
+  it("throws RuntimeError when called with zero arguments", () => {
+    expect(() => run("print()")).toThrow(RuntimeError);
+  });
+
+  it("throws RuntimeError when called with two arguments", () => {
+    expect(() => run("print(1, 2)")).toThrow(RuntimeError);
+  });
+
+  it("can be overwritten by user code", () => {
+    run(`
+      called = 0
+      function myPrint(x) {
+        called = 1
+      }
+      print = myPrint
+      print(42)
+      called
+    `);
+    expect(consoleSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/Interpreter/examples/type.test.ts
+++ b/src/Interpreter/examples/type.test.ts
@@ -1,0 +1,44 @@
+import { Lexer } from "../../Lexer";
+import { Parser } from "../../Parser";
+import { Interpreter } from "../Interpreter";
+import { RuntimeError } from "../errors";
+
+function run(script: string): undefined | boolean | number | string {
+  const tokens = new Lexer(script).tokenize();
+  const ast = new Parser(tokens).parse();
+  return new Interpreter(ast).run();
+}
+
+describe("type builtin", () => {
+  it("returns 'number' for a number", () => {
+    expect(run("type(42)")).toBe("number");
+  });
+
+  it("returns 'string' for a string", () => {
+    expect(run('type("hello")')).toBe("string");
+  });
+
+  it("returns 'boolean' for true", () => {
+    expect(run("type(true)")).toBe("boolean");
+  });
+
+  it("returns 'boolean' for false", () => {
+    expect(run("type(false)")).toBe("boolean");
+  });
+
+  it("returns 'nothing' for nothing", () => {
+    expect(run("type(nothing)")).toBe("nothing");
+  });
+
+  it("returns 'function' for a user-defined function", () => {
+    expect(run("function f() {}\ntype(f)")).toBe("function");
+  });
+
+  it("throws RuntimeError when called with zero arguments", () => {
+    expect(() => run("type()")).toThrow(RuntimeError);
+  });
+
+  it("throws RuntimeError when called with two arguments", () => {
+    expect(() => run("type(1, 2)")).toThrow(RuntimeError);
+  });
+});

--- a/src/Interpreter/objects/LuckyBoolean.test.ts
+++ b/src/Interpreter/objects/LuckyBoolean.test.ts
@@ -2,6 +2,16 @@ import { RuntimeError } from "../errors";
 import { LuckyBoolean } from "./LuckyBoolean";
 import { LuckyNumber } from "./LuckyNumber";
 
+describe("LuckyBoolean.display()", () => {
+  it("returns 'true' for True", () => {
+    expect(LuckyBoolean.True.display()).toBe("true");
+  });
+
+  it("returns 'false' for False", () => {
+    expect(LuckyBoolean.False.display()).toBe("false");
+  });
+});
+
 describe("LuckyBoolean.eq()", () => {
   it("true == true", () => {
     expect(LuckyBoolean.True.eq(LuckyBoolean.True)).toBe(LuckyBoolean.True);

--- a/src/Interpreter/objects/LuckyBoolean.ts
+++ b/src/Interpreter/objects/LuckyBoolean.ts
@@ -12,6 +12,10 @@ export class LuckyBoolean extends LuckyObject {
     return this;
   }
 
+  display(): string {
+    return this.value ? "true" : "false";
+  }
+
   eq(object: LuckyObject): LuckyBoolean {
     this.ensureLuckyBoolean(object);
     return LuckyBoolean.fromNative(this.value === object.value);

--- a/src/Interpreter/objects/LuckyBuiltin.test.ts
+++ b/src/Interpreter/objects/LuckyBuiltin.test.ts
@@ -1,0 +1,26 @@
+import { LuckyBoolean } from "./LuckyBoolean";
+import { LuckyBuiltin } from "./LuckyBuiltin";
+import { LuckyNumber } from "./LuckyNumber";
+
+describe("LuckyBuiltin", () => {
+  it("call() invokes the native function with the provided args", () => {
+    const fn = jest.fn().mockReturnValue(new LuckyNumber(99));
+    const builtin = new LuckyBuiltin("test", 1, fn);
+    const arg = new LuckyNumber(42);
+
+    const result = builtin.call([arg]);
+
+    expect(fn).toHaveBeenCalledWith([arg]);
+    expect(result).toEqual(new LuckyNumber(99));
+  });
+
+  it("display() returns '<builtin name>'", () => {
+    const builtin = new LuckyBuiltin("print", 1, () => new LuckyNumber(0));
+    expect(builtin.display()).toBe("<builtin print>");
+  });
+
+  it("toBoolean() returns True", () => {
+    const builtin = new LuckyBuiltin("print", 1, () => new LuckyNumber(0));
+    expect(builtin.toBoolean()).toBe(LuckyBoolean.True);
+  });
+});

--- a/src/Interpreter/objects/LuckyBuiltin.ts
+++ b/src/Interpreter/objects/LuckyBuiltin.ts
@@ -1,0 +1,26 @@
+import { LuckyBoolean } from "./LuckyBoolean";
+import { LuckyObject } from "./LuckyObject";
+
+type NativeFn = (args: LuckyObject[]) => LuckyObject;
+
+export class LuckyBuiltin extends LuckyObject {
+  constructor(
+    public readonly name: string,
+    public readonly arity: number,
+    private readonly fn: NativeFn,
+  ) {
+    super();
+  }
+
+  call(args: LuckyObject[]): LuckyObject {
+    return this.fn(args);
+  }
+
+  display(): string {
+    return `<builtin ${this.name}>`;
+  }
+
+  toBoolean(): LuckyBoolean {
+    return LuckyBoolean.True;
+  }
+}

--- a/src/Interpreter/objects/LuckyFunction.test.ts
+++ b/src/Interpreter/objects/LuckyFunction.test.ts
@@ -2,6 +2,18 @@ import { LuckyBoolean } from "./LuckyBoolean";
 import { LuckyFunction } from "./LuckyFunction";
 import { SymbolTable } from "../SymbolTable";
 
+describe("LuckyFunction.display()", () => {
+  it("returns '<function name>' for a named function", () => {
+    const fn = new LuckyFunction(new SymbolTable(), "foo", [], []);
+    expect(fn.display()).toBe("<function foo>");
+  });
+
+  it("returns '<function>' for an anonymous function", () => {
+    const fn = new LuckyFunction(new SymbolTable(), undefined, [], []);
+    expect(fn.display()).toBe("<function>");
+  });
+});
+
 describe("LuckyFunction.toBoolean()", () => {
   it("is always True", () => {
     const fn = new LuckyFunction(new SymbolTable(), undefined, [], []);

--- a/src/Interpreter/objects/LuckyFunction.ts
+++ b/src/Interpreter/objects/LuckyFunction.ts
@@ -20,4 +20,8 @@ export class LuckyFunction extends LuckyObject {
   toBoolean(): LuckyBoolean {
     return LuckyBoolean.True;
   }
+
+  display(): string {
+    return this.name ? `<function ${this.name}>` : "<function>";
+  }
 }

--- a/src/Interpreter/objects/LuckyNothing.test.ts
+++ b/src/Interpreter/objects/LuckyNothing.test.ts
@@ -1,0 +1,7 @@
+import { LuckyNothing } from "./LuckyNothing";
+
+describe("LuckyNothing.display()", () => {
+  it("returns 'nothing'", () => {
+    expect(LuckyNothing.Instance.display()).toBe("nothing");
+  });
+});

--- a/src/Interpreter/objects/LuckyNothing.ts
+++ b/src/Interpreter/objects/LuckyNothing.ts
@@ -15,4 +15,8 @@ export class LuckyNothing extends LuckyObject {
   toBoolean(): LuckyBoolean {
     return LuckyBoolean.False;
   }
+
+  display(): string {
+    return "nothing";
+  }
 }

--- a/src/Interpreter/objects/LuckyNumber.test.ts
+++ b/src/Interpreter/objects/LuckyNumber.test.ts
@@ -1,6 +1,16 @@
 import { LuckyBoolean } from "./LuckyBoolean";
 import { LuckyNumber } from "./LuckyNumber";
 
+describe("LuckyNumber.display()", () => {
+  it("returns string representation of integer", () => {
+    expect(new LuckyNumber(42).display()).toBe("42");
+  });
+
+  it("returns string representation of float", () => {
+    expect(new LuckyNumber(3.14).display()).toBe("3.14");
+  });
+});
+
 describe("LuckyNumber.toBoolean()", () => {
   it("returns False for 0", () => {
     expect(new LuckyNumber(0).toBoolean()).toBe(LuckyBoolean.False);

--- a/src/Interpreter/objects/LuckyNumber.ts
+++ b/src/Interpreter/objects/LuckyNumber.ts
@@ -79,4 +79,8 @@ export class LuckyNumber extends LuckyObject {
   toBoolean(): LuckyBoolean {
     return LuckyBoolean.fromNative(this.value !== 0);
   }
+
+  display(): string {
+    return String(this.value);
+  }
 }

--- a/src/Interpreter/objects/LuckyObject.ts
+++ b/src/Interpreter/objects/LuckyObject.ts
@@ -48,6 +48,8 @@ export abstract class LuckyObject {
 
   abstract toBoolean(): LuckyBoolean;
 
+  abstract display(): string;
+
   protected throwIllegalOperationError(): never {
     throw new RuntimeError("Illegal operation");
   }

--- a/src/Interpreter/objects/index.ts
+++ b/src/Interpreter/objects/index.ts
@@ -1,4 +1,5 @@
 export { LuckyBoolean } from "./LuckyBoolean";
+export { LuckyBuiltin } from "./LuckyBuiltin";
 export { LuckyFunction } from "./LuckyFunction";
 export { LuckyNothing } from "./LuckyNothing";
 export { LuckyNumber } from "./LuckyNumber";

--- a/src/examples/booleans.test.ts
+++ b/src/examples/booleans.test.ts
@@ -1,12 +1,4 @@
-import { Lexer } from "../Lexer";
-import { Parser } from "../Parser";
-import { Interpreter } from "../Interpreter/Interpreter";
-
-function run(script: string): undefined | boolean | number | string {
-  const tokens = new Lexer(script).tokenize();
-  const ast = new Parser(tokens).parse();
-  return new Interpreter(ast).run();
-}
+import { run } from "./utils";
 
 describe("Boolean literals", () => {
   it.each`

--- a/src/examples/booleans.test.ts
+++ b/src/examples/booleans.test.ts
@@ -1,6 +1,6 @@
-import { Lexer } from "../../Lexer";
-import { Parser } from "../../Parser";
-import { Interpreter } from "../Interpreter";
+import { Lexer } from "../Lexer";
+import { Parser } from "../Parser";
+import { Interpreter } from "../Interpreter/Interpreter";
 
 function run(script: string): undefined | boolean | number | string {
   const tokens = new Lexer(script).tokenize();

--- a/src/examples/fibonacci.test.ts
+++ b/src/examples/fibonacci.test.ts
@@ -1,6 +1,4 @@
-import { Lexer } from "../Lexer";
-import { Parser } from "../Parser";
-import { Interpreter } from "../Interpreter/Interpreter";
+import { run } from "./utils";
 
 it.each`
   n    | expected
@@ -27,9 +25,7 @@ it.each`
     fib(${n})
   `;
 
-  const tokens = new Lexer(script).tokenize();
-  const ast = new Parser(tokens).parse();
-  const result = new Interpreter(ast).run();
+  const result = run(script);
 
   expect(result).toBe(expected);
 });

--- a/src/examples/fibonacci.test.ts
+++ b/src/examples/fibonacci.test.ts
@@ -1,6 +1,6 @@
-import { Lexer } from "../../Lexer";
-import { Parser } from "../../Parser";
-import { Interpreter } from "../Interpreter";
+import { Lexer } from "../Lexer";
+import { Parser } from "../Parser";
+import { Interpreter } from "../Interpreter/Interpreter";
 
 it.each`
   n    | expected

--- a/src/examples/helloWorld.test.ts
+++ b/src/examples/helloWorld.test.ts
@@ -1,6 +1,6 @@
-import { Lexer } from "../../Lexer";
-import { Parser } from "../../Parser";
-import { Interpreter } from "../Interpreter";
+import { Lexer } from "../Lexer";
+import { Parser } from "../Parser";
+import { Interpreter } from "../Interpreter/Interpreter";
 
 it("sayHello prints a personalised greeting", () => {
   const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});

--- a/src/examples/helloWorld.test.ts
+++ b/src/examples/helloWorld.test.ts
@@ -1,21 +1,15 @@
-import { Lexer } from "../Lexer";
-import { Parser } from "../Parser";
-import { Interpreter } from "../Interpreter/Interpreter";
+import { run } from "./utils";
 
 it("sayHello prints a personalised greeting", () => {
   const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
 
-  const script = `
+  run(`
     function sayHello(name) {
       print("Hello, " + name + "!")
     }
 
     sayHello("World")
-  `;
-
-  const tokens = new Lexer(script).tokenize();
-  const ast = new Parser(tokens).parse();
-  new Interpreter(ast).run();
+  `);
 
   expect(consoleSpy).toHaveBeenCalledWith("Hello, World!");
 

--- a/src/examples/print.test.ts
+++ b/src/examples/print.test.ts
@@ -1,7 +1,7 @@
-import { Lexer } from "../../Lexer";
-import { Parser } from "../../Parser";
-import { Interpreter } from "../Interpreter";
-import { RuntimeError } from "../errors";
+import { Lexer } from "../Lexer";
+import { Parser } from "../Parser";
+import { Interpreter } from "../Interpreter/Interpreter";
+import { RuntimeError } from "../Interpreter/errors";
 
 function run(script: string): undefined | boolean | number | string {
   const tokens = new Lexer(script).tokenize();

--- a/src/examples/print.test.ts
+++ b/src/examples/print.test.ts
@@ -1,13 +1,5 @@
-import { Lexer } from "../Lexer";
-import { Parser } from "../Parser";
-import { Interpreter } from "../Interpreter/Interpreter";
 import { RuntimeError } from "../Interpreter/errors";
-
-function run(script: string): undefined | boolean | number | string {
-  const tokens = new Lexer(script).tokenize();
-  const ast = new Parser(tokens).parse();
-  return new Interpreter(ast).run();
-}
+import { run } from "./utils";
 
 describe("print builtin", () => {
   let consoleSpy: jest.SpyInstance;

--- a/src/examples/strings.test.ts
+++ b/src/examples/strings.test.ts
@@ -1,12 +1,4 @@
-import { Lexer } from "../Lexer";
-import { Parser } from "../Parser";
-import { Interpreter } from "../Interpreter/Interpreter";
-
-function run(script: string): undefined | boolean | number | string {
-  const tokens = new Lexer(script).tokenize();
-  const ast = new Parser(tokens).parse();
-  return new Interpreter(ast).run();
-}
+import { run } from "./utils";
 
 describe("string literals", () => {
   it("evaluates a simple string literal", () => {

--- a/src/examples/strings.test.ts
+++ b/src/examples/strings.test.ts
@@ -1,6 +1,6 @@
-import { Lexer } from "../../Lexer";
-import { Parser } from "../../Parser";
-import { Interpreter } from "../Interpreter";
+import { Lexer } from "../Lexer";
+import { Parser } from "../Parser";
+import { Interpreter } from "../Interpreter/Interpreter";
 
 function run(script: string): undefined | boolean | number | string {
   const tokens = new Lexer(script).tokenize();

--- a/src/examples/type.test.ts
+++ b/src/examples/type.test.ts
@@ -1,13 +1,5 @@
-import { Lexer } from "../Lexer";
-import { Parser } from "../Parser";
-import { Interpreter } from "../Interpreter/Interpreter";
 import { RuntimeError } from "../Interpreter/errors";
-
-function run(script: string): undefined | boolean | number | string {
-  const tokens = new Lexer(script).tokenize();
-  const ast = new Parser(tokens).parse();
-  return new Interpreter(ast).run();
-}
+import { run } from "./utils";
 
 describe("type builtin", () => {
   it("returns 'number' for a number", () => {

--- a/src/examples/type.test.ts
+++ b/src/examples/type.test.ts
@@ -1,7 +1,7 @@
-import { Lexer } from "../../Lexer";
-import { Parser } from "../../Parser";
-import { Interpreter } from "../Interpreter";
-import { RuntimeError } from "../errors";
+import { Lexer } from "../Lexer";
+import { Parser } from "../Parser";
+import { Interpreter } from "../Interpreter/Interpreter";
+import { RuntimeError } from "../Interpreter/errors";
 
 function run(script: string): undefined | boolean | number | string {
   const tokens = new Lexer(script).tokenize();

--- a/src/examples/utils.ts
+++ b/src/examples/utils.ts
@@ -1,0 +1,9 @@
+import { Lexer } from "../Lexer";
+import { Parser } from "../Parser";
+import { Interpreter } from "../Interpreter";
+
+export function run(script: string): undefined | boolean | number | string {
+  const tokens = new Lexer(script).tokenize();
+  const ast = new Parser(tokens).parse();
+  return new Interpreter(ast).run();
+}


### PR DESCRIPTION
This pull request introduces two new built-in functions to the Lucky Script interpreter: `print(x)` and `type(x)`. It also establishes a protocol for native (JS-backed) built-ins, enforces a `display()` method on all runtime value types, and adds comprehensive tests and specs for these features. The changes are organized around extensibility, runtime introspection, and improved testability.

